### PR TITLE
Add failures to the flight log

### DIFF
--- a/src/ModuleTestLite.cs
+++ b/src/ModuleTestLite.cs
@@ -305,6 +305,7 @@ namespace TestLite
 			updateCore(); /* Make sure we save our failureData, just in case we explode the part */
 			Logging.LogFormat("Failing engine {0}: {1}", configuration, ft.ToString());
 			ScreenMessages.PostScreenMessage(String.Format("[TestLite] {0} on {1}", failureDescription[type], configuration), 5f);
+			FlightLogger.eventLog.Add(String.Format("[{0}] {1} on {2}", KSPUtil.PrintTimeCompact((int)Math.Floor(this.vessel.missionTime), false), failureDescription[type], configuration));
 			switch (severityType[type]) {
 			case 0:
 				transient_failure = true;


### PR DESCRIPTION
A small patch to add failure events to the flight log, so they can be reviewed whilst picking through the wreckage.