### PR TITLE
No failure data until launched, roll off on overburn

### DIFF
--- a/src/ModuleTestLite.cs
+++ b/src/ModuleTestLite.cs
@@ -341,7 +341,12 @@ namespace TestLite
 					type = (int)failureTypes.PERFLOSS;
 				}
 			}
-			failure_du += failureData[type];
+            // No failure data until the craft has launched
+            if (runTime > clampTime)
+            {
+                // Roll off data above rated run time, to a minimum of 10%
+			    failure_du += failureData[type] * Math.Min(Math.Sqrt(Math.Max(2d - runTime / ratedBurnTime, 0.01d)), 1d);
+            }
 			failureTypes ft = (failureTypes)type;
 			updateCore(); /* Make sure we save our failureData, just in case we explode the part */
 			Logging.LogFormat("Failing engine {0}: {1}", configuration, ft.ToString());


### PR DESCRIPTION
Failure data is not accrued on unlaunched craft.
Failure data rolls off when overburning engines, to a minimum of 10% of nominal.