### PR TITLE
User configurable starting du

### DIFF
--- a/src/Core.cs
+++ b/src/Core.cs
@@ -90,12 +90,15 @@ namespace TestLite
 		public bool determinismMode = false;
 		[GameParameters.CustomParameterUI("Pre-Launch Ignition Failures Enabled?", toolTip = "Set to enable ignition failures on the Launch Pad.")]
 		public bool preLaunchFailures = true;
+		[GameParameters.CustomFloatParameterUI("Start with du", minValue = 0, maxValue = 10000, stepCount = 21, toolTip = "Set to have engines start at this du.")]
+		public float startingDu = 0;
 
 		public override void SetDifficultyPreset(GameParameters.Preset preset)
 		{
 			if (preset == GameParameters.Preset.Custom)
 				return; /* Leave whatever was set before */
 			disabled = false;
+			startingDu = 0;
 			switch (preset) {
 			case GameParameters.Preset.Easy:
 				determinismMode = true;

--- a/src/ModuleTestLite.cs
+++ b/src/ModuleTestLite.cs
@@ -95,6 +95,7 @@ namespace TestLite
 		public string configuration;
 
 		private bool preLaunchFailures = true, determinismMode = false, disableTestLite = false;
+		private float startingDu = 0;
 
 		[KSPField()]
 		public double maxData;
@@ -303,7 +304,7 @@ namespace TestLite
 			if (Core.Instance == null)
 				return;
 			if (!Core.Instance.du.ContainsKey(configuration)) /* should never happen */
-				Core.Instance.du[configuration] = 0d;
+				Core.Instance.du[configuration] = startingDu;
 			Core.Instance.du[configuration] = Math.Max(local_du, Core.Instance.du[configuration]);
 		}
 
@@ -446,7 +447,7 @@ namespace TestLite
 			if (Core.Instance == null)
 				return;
 			if (!Core.Instance.du.TryGetValue(configuration, out in_du_vab)) {
-				in_du_vab = 0;
+				in_du_vab = startingDu;
 				Core.Instance.du[configuration] = in_du_vab;
 			}
 		}
@@ -457,7 +458,7 @@ namespace TestLite
 			if (!HighLogic.LoadedSceneIsFlight) {
 				updateDuVAB();
 			} else if (!Core.Instance.du.TryGetValue(configuration, out in_du)) {
-				in_du = 0;
+				in_du = startingDu;
 				Core.Instance.du[configuration] = in_du;
 			}
 		}
@@ -481,6 +482,15 @@ namespace TestLite
 
 			if (Core.Instance == null)
 				return;
+			if (HighLogic.CurrentGame != null) {
+				TestLiteGameSettings settings = HighLogic.CurrentGame.Parameters.CustomParams<TestLiteGameSettings>();
+				if (settings != null) {
+					preLaunchFailures = settings.preLaunchFailures;
+					determinismMode = settings.determinismMode;
+					disableTestLite = settings.disabled;
+					startingDu = settings.startingDu;
+				}
+			}
 			if (editor)
 				clearFlightState();
 			if (in_du < 0d || editor || prelaunch)
@@ -489,14 +499,6 @@ namespace TestLite
 				roll_du_vab = total_du;
 			else if (prelaunch)
 				roll_du = total_du;
-			if (HighLogic.CurrentGame != null) {
-				TestLiteGameSettings settings = HighLogic.CurrentGame.Parameters.CustomParams<TestLiteGameSettings>();
-				if (settings != null) {
-					preLaunchFailures = settings.preLaunchFailures;
-					determinismMode = settings.determinismMode;
-					disableTestLite = settings.disabled;
-				}
-			}
 			updateFailureRate();
 			if (!editor)
 				Roll();


### PR DESCRIPTION
Adds a slider for starting du to the difficulty options (defaults to 0 for all presets).
Starting du is applied to engines not yet used in that save but is not retrospective on used engines if the setting is changed mid game.