### PR TITLE
Reinitialise on OnGameSettingsApplied event

### DIFF
--- a/src/ModuleTestLite.cs
+++ b/src/ModuleTestLite.cs
@@ -535,6 +535,18 @@ namespace TestLite
 			Initialise();
 		}
 
+		public override void OnStartFinished(StartState state)
+		{
+			base.OnStartFinished(state);
+			if (HighLogic.LoadedSceneIsFlight)
+				GameEvents.OnGameSettingsApplied.Add(Initialise);
+		}
+
+		public void OnDestroy()
+		{
+			GameEvents.OnGameSettingsApplied.Remove(Initialise);
+		}
+
 		public void LoadTechTransfer(string text)
 		{
 			if (string.IsNullOrEmpty(text))


### PR DESCRIPTION
Primary use-case for this change is to allow KCT simulations to disable TL at the start of the flight scene. Additionally TL will now toggle itself mid-flight when the user manually changes the *Disabled* setting from the menu.